### PR TITLE
Update tlassemble.m

### DIFF
--- a/tlassemble.m
+++ b/tlassemble.m
@@ -629,7 +629,7 @@ int main(int argc, char* const argv[]) {
 
                     break;
                 }
-                case '2': {
+                case 2: {
                     char *end = NULL;
                     fps = strtod(optarg, &end);
 


### PR DESCRIPTION
error on --fps flag caused by char vs integer case